### PR TITLE
removed selectors which made it impossible to overwrite the background color of input fields

### DIFF
--- a/blueprint/screen.css
+++ b/blueprint/screen.css
@@ -84,15 +84,14 @@ fieldset {padding:0 1.4em 1.4em 1.4em;margin:0 0 1.5em 0;border:1px solid #ccc;}
 legend {font-weight:bold;font-size:1.2em;margin-top:-0.2em;margin-bottom:1em;}
 fieldset, #IE8#HACK {padding-top:1.4em;}
 legend, #IE8#HACK {margin-top:0;margin-bottom:0;}
-input[type=text], input[type=password], input[type=url], input[type=email], input.text, input.title, textarea {background-color:#fff;border:1px solid #bbb;color:#000;}
+input, select, textarea {background-color:#fff;border:1px solid #bbb;color:#000;}
 input[type=text]:focus, input[type=password]:focus, input[type=url]:focus, input[type=email]:focus, input.text:focus, input.title:focus, textarea:focus {border-color:#666;}
-select {background-color:#fff;border-width:1px;border-style:solid;}
 input[type=text], input[type=password], input[type=url], input[type=email], input.text, input.title, textarea, select {margin:0.5em 0;}
 input.text, input.title {width:300px;padding:5px;}
 input.title {font-size:1.5em;}
 textarea {width:390px;height:250px;padding:5px;}
 form.inline {line-height:3;}
-form.inline p {margin-bottom:0;}
+form.inline p {margin-bottom:0;} 
 .error, .alert, .notice, .success, .info {padding:0.8em;margin-bottom:1em;border:2px solid #ddd;}
 .error, .alert {background:#fbe3e4;color:#8a1f11;border-color:#fbc2c4;}
 .notice {background:#fff6bf;color:#514721;border-color:#ffd324;}

--- a/blueprint/src/forms.css
+++ b/blueprint/src/forms.css
@@ -30,9 +30,8 @@ legend, #IE8#HACK { margin-top:0; margin-bottom:0; }
   add classes for each one. ".title" simply creates a large text
   field, this is purely for looks.
  */
-input[type=text], input[type=password], input[type=url], input[type=email],
-input.text, input.title,
-textarea {
+
+input, select, textarea {
   background-color:#fff;
   border:1px solid #bbb;
   color:#000;
@@ -42,7 +41,6 @@ input.text:focus, input.title:focus,
 textarea:focus {
   border-color:#666;
 }
-select { background-color:#fff; border-width:1px; border-style:solid; }
 
 input[type=text], input[type=password], input[type=url], input[type=email],
 input.text, input.title,


### PR DESCRIPTION
If one wants to change the background color of an input field, this would currently fail (tested in FF3.6.17) as the selectors ([type=...]) take precedence.

With this patch one is able to e.g. have a red input field with <input class="error" ... />

Let me know if it negatively influences other areas of blueprint.
