### PR TITLE
Define a left border column, i.e. `colborderleft`

### DIFF
--- a/blueprint/screen.css
+++ b/blueprint/screen.css
@@ -205,6 +205,7 @@ input.span-24, textarea.span-24 {width:938px;}
 .prepend-23 {padding-left:920px;}
 .border {padding-right:4px;margin-right:5px;border-right:1px solid #ddd;}
 .colborder {padding-right:24px;margin-right:25px;border-right:1px solid #ddd;}
+.colborderleft {padding-left:20px;margin-left:19px;border-left:1px solid #ddd;}
 .pull-1 {margin-left:-40px;}
 .pull-2 {margin-left:-80px;}
 .pull-3 {margin-left:-120px;}


### PR DESCRIPTION
I added a vertical line that takes up 1 col, for use on the left of a `span-n` block.

Sometimes, the `colborder` is no use because the left column (which has the right border) has less text content than the right column which means the vertical border stops before the text content of the right content. This looks bad. To rectify you need a left border on the right column.
