### PR TITLE
Lion appears to have broken Warnock Pro in Safari

### DIFF
--- a/blueprint/plugins/fancy-type/screen.css
+++ b/blueprint/plugins/fancy-type/screen.css
@@ -18,7 +18,7 @@
 
 .alt {
   color: #666;
-  font-family: "Warnock Pro", "Goudy Old Style","Palatino","Book Antiqua", Georgia, serif;
+  font-family:"Goudy Old Style","Palatino","Book Antiqua", Georgia, serif;
   font-style: italic;
   font-weight: normal;
 }


### PR DESCRIPTION
It's been my experience that across Firefox, Safari and Chrome, Warnock
Pro displays vary wildly. In OSX Lion on Safari 5.1, it now displays as
unknown character encoding blocks. Remove it from the font stack be done
with it.
