### PR TITLE
Remove Goudy due to IE9 sucking and making it always appear in italics

### DIFF
--- a/blueprint/plugins/fancy-type/screen.css
+++ b/blueprint/plugins/fancy-type/screen.css
@@ -18,7 +18,7 @@
 
 .alt {
   color: #666;
-  font-family: "Warnock Pro", "Goudy Old Style","Palatino","Book Antiqua", Georgia, serif;
+  font-family: "Warnock Pro","Palatino","Book Antiqua", Georgia, serif;
   font-style: italic;
   font-weight: normal;
 }


### PR DESCRIPTION
...http://stackoverflow.com/questions/8868222/why-does-goudy-old-style-only-display-in-italics-in-ie9 and http://stackoverflow.com/questions/7910391/ie9-causes-all-webpage-text-to-render-as-italic-when-font-familygoudy-oldstyle
